### PR TITLE
Add a quick install script for macOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This theme changes the font, it's feels easier to read. You can install from htt
 
 ## Second
 
-Copy the CSS into place, on OSX.
+If you're running macOS, run install-macos.sh. Otherwise, proceed manually:
+
+Copy the CSS into place, on macOS.
 
 ```
 cp caiceA.css dark.css /Applications/Slack.app/Contents/Resources

--- a/mac-install.sh
+++ b/mac-install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Sanity checks
+if [ "$UID" != "0" ]; then
+	echo "You must run this script as root. Try running sudo $0"
+	exit 126
+fi
+
+if [ $(uname) != "Darwin" ]; then
+	echo "This script only works with MacOS."
+	exit 1
+fi
+
+cp -v caiceA.css dark.css /Applications/Slack.app/Contents/Resources
+
+if [ $? != "0" ]; then
+	echo "Failed copying CSS into Slack's resource folder"
+	exit 2
+fi
+
+cat ssb-interop-patch.js >> /Applications/Slack.app/Contents/Resources/app.asar.unpacked/src/static/ssb-interop.js
+
+if [ $? != "0" ]; then
+	echo "Failed patching Slack's javascript"
+	exit 2
+fi
+
+echo "Done. Restart or refresh Slack (⌘+-r) to see the changes."
+exit 0
+
+


### PR DESCRIPTION
I've got a first time setup script I run through as part of setting up any new mac machine, and I've incorporated your theme into that setup. So, I wrote a quick script that can be invoked as a one-off to make the changes.

Figured you may or may not want this on your repo.

Thanks for the theme!